### PR TITLE
[ENH] add support for parsing docutils contents directives

### DIFF
--- a/sphinxcontrib/tomyst/writers/myst.py
+++ b/sphinxcontrib/tomyst/writers/myst.py
@@ -61,11 +61,13 @@ class MystSyntax(MarkdownSyntax):
 
     # - Syntax Methods - #
 
-    def visit_directive(self, type, options=None):
+    def visit_directive(self, type, title=None, options=None):
+        directive = "```{" + "{}".format(type) + "}"
+        if title:
+            directive += " {}".format(title)
         if options:
-            return "```{" + "{}".format(type) + "}" + "\n{}".format("\n".join(options))
-        else:
-            return "```{" + "{}".format(type) + "}"
+            directive += "\n{}".format("\n".join(options))
+        return directive
 
     def depart_directive(self):
         return "```"

--- a/tests/source/docutils/directives.rst
+++ b/tests/source/docutils/directives.rst
@@ -34,6 +34,20 @@ caution
 
    This is a caution admonition
 
+contents
+--------
+
+.. contents::
+
+.. contents:: Table of Contents
+
+.. contents::
+   :depth: 2
+   :local:
+   :backlinks: entry
+   :class: testing
+
+
 danger
 ------
 

--- a/tests/test_build/test_docutils.myst
+++ b/tests/test_build/test_docutils.myst
@@ -137,6 +137,23 @@ This is an attention admonition
 This is a caution admonition
 ```
 
+## contents
+
+```{contents} Contents
+```
+
+```{contents} Table of Contents
+```
+
+```{contents}
+---
+backlinks: entry
+class: testing
+depth: 2
+local: 
+---
+```
+
 ## danger
 
 ```{danger}


### PR DESCRIPTION
This adds support for migrating `contents` directives provided by `docutils`

```rst
.. contents::
```

all specified directive options are migrated from the pre-transform `pending` node.

https://docutils.sourceforge.io/docs/ref/rst/directives.html#table-of-contents