### PR TITLE
[FIX] fix to skip system message text in output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
           cd lecture-python-programming/_build/myst/
           make html
       - name: Preview Deploy to Netlify
-        uses: nwtgck/actions-netlify@v1.0
+        uses: nwtgck/actions-netlify@v1.1
         with:
           publish-dir: 'lecture-python-programming/_build/myst/_build/html/'
           production-branch: master

--- a/sphinxcontrib/tomyst/writers/translator.py
+++ b/sphinxcontrib/tomyst/writers/translator.py
@@ -1248,8 +1248,9 @@ file will be included in the myst directive".format(fn, line)
     # https://docutils.sourceforge.io/docs/ref/doctree.html#system-message
 
     def visit_system_message(self, node):
-        msg = "[system_mesage] typically handeled by transform/post-transform"
+        msg = "[system_mesage] typically handeled by transform/post-transform\n\n{}".format(node.astext())
         logger.info(msg)
+        raise nodes.SkipNode
 
     def depart_system_message(self, node):
         pass
@@ -1374,7 +1375,6 @@ file will be included in the myst directive".format(fn, line)
         self.add_newparagraph()
         self.output.append("\n".join(listing))
         self.add_newline()
-        # import pdb; pdb.set_trace()   #implement toctree option parsing
 
     def infer_toctree_attrs(self, node):
         """

--- a/tests/snippet.py
+++ b/tests/snippet.py
@@ -16,5 +16,5 @@ def test_snippet(
 ):
     """basic test."""
     app.build()
-    output = get_sphinx_app_output(app, files=["snippet.myst"], regress=True)
+    output = get_sphinx_app_output(app, files=["snippet.md"], regress=True)
     print(output)

--- a/tests/snippet/test_snippet.myst
+++ b/tests/snippet/test_snippet.myst
@@ -1,24 +1,14 @@
-------------
-snippet.myst
-------------
+----------
+snippet.md
+----------
 
 # Snippet
 
-A bullet list
+## QuantEcon Notes
 
-- 
+QuantEcon has its own site for sharing Jupyter notebooks related
+to economics -- [QuantEcon Notes](http://notes.quantecon.org/).
 
-  - 
-
-- 
-
-  - 
-
-  - 
-
-- first item level 0
-  - first item of first item (level 0)
-- second item level 0
-  - first item of second item (level 0)
-  - second item of second item (level 0)
+Notebooks submitted to QuantEcon Notes can be shared with a link, and are open
+to comments and votes by the community.
 

--- a/tests/source/snippet/snippet.rst
+++ b/tests/source/snippet/snippet.rst
@@ -1,13 +1,11 @@
 Snippet
 =======
 
-A bullet list
+QuantEcon Notes
+---------------
 
-- first item level 0
+QuantEcon has its own site for sharing Jupyter notebooks related
+to economics -- `QuantEcon Notes <http://notes.quantecon.org/>`_.
 
-  - first item of first item (level 0)
-
-- second item level 0
-
-  - first item of second item (level 0)
-  - second item of second item (level 0)
+Notebooks submitted to QuantEcon Notes can be shared with a link, and are open
+to comments and votes by the community.


### PR DESCRIPTION
This add a `skipnode` operation for `system messages` to prevent text from entering output. These system messages are no longer handled as we intercept the `AST` prior to `transforms/post-transforms`