### PR TITLE
[ENH] improve jupytext targeting

### DIFF
--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -11,7 +11,11 @@ An array which takes path of your static folders, relative to the project's ``co
 
 For config variable: ``tomyst_static_file_path: ["source/_static"]``, the contents of this folder will be copied over to ``_build/myst/source/_static``.
 
+**tomyst_jupytext**:
+
+[True/False] Enable targetting of jupytext
+
 **tomyst_jupytext_header**:
 
-Enable the inclusion of a `jupytext header <https://myst-nb.readthedocs.io/en/latest/use/markdown.html>`__  
-to enable automatic execution using `myst-nb <https://github.com/executablebooks/MyST-NB>`__
+Can specify a custom `jupytext header <https://myst-nb.readthedocs.io/en/latest/use/markdown.html>`__  
+to support jupytext compatibility and execution using `myst-nb <https://github.com/executablebooks/MyST-NB>`__

--- a/sphinxcontrib/tomyst/__init__.py
+++ b/sphinxcontrib/tomyst/__init__.py
@@ -5,12 +5,29 @@ from sphinx.application import Sphinx
 from .builders import MystBuilder
 from .transform import InterceptAST
 
+DEFAULT_JUPYTEXT_HEADER="""
+---
+jupytext:
+  formats: md:myst
+  text_representation:
+    extension: .md
+    format_name: myst
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
+---
+"""
+
 def setup(app: Sphinx) -> Dict[str, Any]:
     app.add_builder(MystBuilder)
 
     app.add_transform(InterceptAST)
     app.add_config_value("tomyst_static_file_path", ['_static'], "tomyst")
-    app.add_config_value("tomyst_jupytext_header", None, "tomyst")
+    
+    #JupyText Compatibility
+    app.add_config_value("tomyst_jupytext", False, "tomyst")
+    app.add_config_value("tomyst_jupytext_header", DEFAULT_JUPYTEXT_HEADER, "tomyst")
 
     return {
         'version': 'builtin',

--- a/sphinxcontrib/tomyst/writers/myst.py
+++ b/sphinxcontrib/tomyst/writers/myst.py
@@ -7,6 +7,7 @@ from .markdown import MarkdownSyntax
 class MystSyntax(MarkdownSyntax):
 
     indentation = " " * 2
+    target_jupytext = False
 
     # - Direct Syntax - #
 
@@ -38,7 +39,10 @@ class MystSyntax(MarkdownSyntax):
         if language is None:
             return "```"
         else:
-            return "```{{code-block}} {0}".format(language)
+            if self.target_jupytext:
+                return "```{{code-cell}} {0}".format(language)
+            else:
+                return "```{{code-block}} {0}".format(language)
 
     def visit_target(self, target):
         return "({})=".format(target)

--- a/sphinxcontrib/tomyst/writers/translator.py
+++ b/sphinxcontrib/tomyst/writers/translator.py
@@ -110,6 +110,7 @@ class MystTranslator(SphinxTranslator):
         """
         super().__init__(document, builder)
         self.syntax = MystSyntax()
+        self.syntax.target_jupytext = self.builder.config['tomyst_jupytext']
         self.default_ext = ".myst"
         self.images = []
         self.section_level = 0
@@ -120,7 +121,7 @@ class MystTranslator(SphinxTranslator):
 
     def visit_document(self, node):
         self.output = []
-        if self.builder.config['tomyst_jupytext_header'] is not None:
+        if self.builder.config['tomyst_jupytext']:
             self.output.append(self.builder.config['tomyst_jupytext_header'].lstrip())
             self.add_newline()
 

--- a/tests/source/jupytext-header/conf.py
+++ b/tests/source/jupytext-header/conf.py
@@ -1,10 +1,4 @@
 extensions = ["sphinxcontrib.tomyst"]
 exclude_patterns = ["_build"]
 
-tomyst_jupytext_header = """
----
-kernelspec:
-  display_name: Python 3
-  name: python3
----
-"""
+tomyst_jupytext = True

--- a/tests/test_build/test_jupytext.myst
+++ b/tests/test_build/test_jupytext.myst
@@ -3,8 +3,14 @@ index.md
 --------
 
 ---
+jupytext:
+  formats: md:myst
+  text_representation:
+    extension: .md
+    format_name: myst
 kernelspec:
   display_name: Python 3
+  language: python
   name: python3
 ---
 
@@ -25,8 +31,14 @@ content.md
 ----------
 
 ---
+jupytext:
+  formats: md:myst
+  text_representation:
+    extension: .md
+    format_name: myst
 kernelspec:
   display_name: Python 3
+  language: python
   name: python3
 ---
 
@@ -34,7 +46,7 @@ kernelspec:
 
 Simple code example
 
-```{code-block} python3
+```{code-cell} python3
 import numpy as np
 np.__version__
 ```


### PR DESCRIPTION
This PR adds improvements to `jupytext` targeting by enabling a context switch in some syntax such as ``code-block`` becomes ``code-cell``. It also adds a default `python` setup for `jupytext` headers