### PR TITLE
[FIX] remove line causing issues with jupytext=1.6

### DIFF
--- a/sphinxcontrib/tomyst/__init__.py
+++ b/sphinxcontrib/tomyst/__init__.py
@@ -8,7 +8,6 @@ from .transform import InterceptAST
 DEFAULT_JUPYTEXT_HEADER="""
 ---
 jupytext:
-  formats: md:myst
   text_representation:
     extension: .md
     format_name: myst

--- a/tests/test_build/test_jupytext.myst
+++ b/tests/test_build/test_jupytext.myst
@@ -4,7 +4,6 @@ index.md
 
 ---
 jupytext:
-  formats: md:myst
   text_representation:
     extension: .md
     format_name: myst
@@ -32,7 +31,6 @@ content.md
 
 ---
 jupytext:
-  formats: md:myst
   text_representation:
     extension: .md
     format_name: myst


### PR DESCRIPTION
Adjust default `jupytext` header configuration